### PR TITLE
Bump to version 1.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+08-11-2017
+  - Version 1.0.0
+  - Other than the version number, no difference from 0.1.4
+
 11-08-2017
   - Version 0.1.4
   - Return preferred extension when looking up by content type

--- a/lib/mini_mime/version.rb
+++ b/lib/mini_mime/version.rb
@@ -1,3 +1,3 @@
 module MiniMime
-  VERSION = "0.1.4"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
This gem is depended on by the `mail` gem, which is depended on by `actionmailer`, which is depended on `rails`. This means that every single Rails installation will install this gem, and that means that this gem will be used in production environments.

[semver.org explains that versions < 1.x](http://semver.org/#spec-item-4)...

> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.

I think that because this gem is now being used in production environments, it would be sensible to consider that the API here _is_ stable and reliable. 

Leaving this version at 0.1.4 would indicate that the API _could_ change, which may cause issues for `mail`, due to its relaxed version dependency (currently, `>= 0.1.1`). Changing the API for mini_mime will require API changes to `mail` too. 

It's for this reason that we should indicate that `mini_mime`'s API is stable with a 1.0.0 version number.