### PR TITLE
Adjusting lookup_by_filename on performance & style

### DIFF
--- a/lib/mini_mime.rb
+++ b/lib/mini_mime.rb
@@ -39,17 +39,12 @@ module MiniMime
 
     def self.lookup_by_filename(filename)
       extension = File.extname(filename)
-      if extension
-        extension.sub!(".", "")
-        extension.downcase!
-        if extension.length > 0
-          LOCK.synchronize do
-            @db ||= new
-            @db.lookup_by_extension(extension)
-          end
-        else
-          nil
-        end
+      return if extension.empty?
+      extension.sub!('.'.freeze, ''.freeze)
+      extension.downcase!
+      LOCK.synchronize do
+        @db ||= new
+        @db.lookup_by_extension(extension)
       end
     end
 


### PR DESCRIPTION
Having the fact that `File.extname` returns an empty string on the edge cases (no extension, '.', not-valid-paths, etc), we can remove a superflous `if` statement and replace the inner `else` with a single guard.

This improve the performance up to 10% on cached and non_cached values
Also, we can reduce the allocated memory:

Before: 56689 bytes (376 objects)
After:  56291 bytes (371 objects)
Diff:     398 bytes (  5 objects)