### PR TITLE
Allow custom db paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem "mime-types", "~> 3" if RUBY_VERSION > '2'
+gem "memory_profiler"
+gem "benchmark-ips"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ MiniMime.lookup_by_content_type("text/plain").binary?
 
 ```
 
+## Configuration
+
+If you'd like to add your own mime types, try using custom database files:
+
+```
+MiniMime::Configuration.ext_db_path = "path_to_file_extension_db"
+MiniMime::Configuration.content_type_db_path = "path_to_content_type_db"
+```
+
+Check out the [default databases](lib/db) for proper formatting and structure hints.
+
 ## Performance
 
 MiniMime is optimised to minimize memory usage. It keeps a cache of 100 mime type lookups (and 100 misses). There are benchmarks in the [bench directory](https://github.com/discourse/mini_mime/blob/master/bench/bench.rb)

--- a/README.md
+++ b/README.md
@@ -51,32 +51,32 @@ MiniMime is optimised to minimize memory usage. It keeps a cache of 100 mime typ
 
 ```
 Memory stats for requiring mime/types/columnar
-Total allocated: 8686910 bytes (102917 objects)
-Total retained:  3156016 bytes (33593 objects)
+Total allocated: 8712144 bytes (98242 objects)
+Total retained:  3372545 bytes (33599 objects)
 
 Memory stats for requiring mini_mime
-Total allocated: 41064 bytes (362 objects)
-Total retained:  7156 bytes (60 objects)
+Total allocated: 42625 bytes (369 objects)
+Total retained:  8992 bytes (72 objects)
 Warming up --------------------------------------
 cached content_type lookup MiniMime
-                        72.481k i/100ms
+                        85.109k i/100ms
 content_type lookup MIME::Types
-                        13.284k i/100ms
+                        17.879k i/100ms
 Calculating -------------------------------------
 cached content_type lookup MiniMime
-                        914.838k (± 1.3%) i/s -      4.639M in   5.071456s
+                          1.105M (± 4.1%) i/s -      5.532M in   5.014895s
 content_type lookup MIME::Types
-                        140.215k (± 3.4%) i/s -    704.052k in   5.026273s
+                        193.528k (± 7.1%) i/s -    965.466k in   5.013925s
 Warming up --------------------------------------
 uncached content_type lookup MiniMime
-                         1.329k i/100ms
+                         1.410k i/100ms
 content_type lookup MIME::Types
-                        13.225k i/100ms
+                        18.012k i/100ms
 Calculating -------------------------------------
 uncached content_type lookup MiniMime
-                         13.338k (± 1.7%) i/s -     67.779k in   5.083373s
+                         14.689k (± 4.2%) i/s -     73.320k in   5.000779s
 content_type lookup MIME::Types
-                        139.626k (± 4.2%) i/s -    700.925k in   5.027074s
+                        193.459k (± 6.9%) i/s -    972.648k in   5.050731s
 ```
 
 As a general guideline, cached lookups are 6x faster than MIME::Types equivalent. Uncached lookups are 10x slower.

--- a/lib/mini_mime.rb
+++ b/lib/mini_mime.rb
@@ -14,6 +14,16 @@ module MiniMime
     Db.lookup_by_content_type(mime)
   end
 
+  module Configuration
+    class << self
+      attr_accessor :ext_db_path
+      attr_accessor :content_type_db_path
+    end
+
+    self.ext_db_path = File.expand_path("../db/ext_mime.db", __FILE__)
+    self.content_type_db_path = File.expand_path("../db/content_type_mime.db", __FILE__)
+  end
+
   class Info
     BINARY_ENCODINGS = %w(base64 8bit)
 
@@ -83,8 +93,8 @@ module MiniMime
     class RandomAccessDb
       MAX_CACHED = 100
 
-      def initialize(name, sort_order)
-        @path = File.expand_path("../db/#{name}", __FILE__)
+      def initialize(path, sort_order)
+        @path = path
         @file = File.open(@path)
 
         @row_length = @file.readline.length
@@ -141,8 +151,8 @@ module MiniMime
     end
 
     def initialize
-      @ext_db = RandomAccessDb.new("ext_mime.db", 0)
-      @content_type_db = RandomAccessDb.new("content_type_mime.db", 1)
+      @ext_db = RandomAccessDb.new(Configuration.ext_db_path, 0)
+      @content_type_db = RandomAccessDb.new(Configuration.content_type_db_path, 1)
     end
 
     def lookup_by_extension(extension)

--- a/test/fixtures/custom_content_type_mime.db
+++ b/test/fixtures/custom_content_type_mime.db
@@ -1,0 +1,2 @@
+liquid      application/x-liquid                                                      8bit
+mp4         video/vnd.objectvideo                                                     quoted-printable

--- a/test/fixtures/custom_ext_mime.db
+++ b/test/fixtures/custom_ext_mime.db
@@ -1,0 +1,2 @@
+lua         application/x-lua                                                         8bit
+m4v         video/vnd.objectvideo                                                     quoted-printable

--- a/test/mini_mime/configuration_test.rb
+++ b/test/mini_mime/configuration_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class MiniMime::ConfigurationTest < Minitest::Test
+  CUSTOM_EXT_MIME_DB_PATH = File.expand_path("../../fixtures/custom_ext_mime.db", __FILE__)
+  CUSTOM_CONTENT_TYPE_MIME_DB_PATH = File.expand_path("../../fixtures/custom_content_type_mime.db", __FILE__)
+
+  def setup
+    MiniMime::Db.instance_variable_set(:@db, nil)
+    @old_ext_db_path = MiniMime::Configuration.ext_db_path
+    @old_content_type_db_path = MiniMime::Configuration.content_type_db_path
+  end
+
+  def teardown
+    MiniMime::Db.instance_variable_set(:@db, nil)
+    MiniMime::Configuration.ext_db_path = @old_ext_db_path
+    MiniMime::Configuration.content_type_db_path = @old_content_type_db_path
+  end
+
+  def test_using_custom_ext_mime_db
+    MiniMime::Configuration.ext_db_path = CUSTOM_EXT_MIME_DB_PATH
+
+    assert_equal "application/x-lua", MiniMime.lookup_by_extension("lua").content_type
+    assert_equal "quoted-printable", MiniMime.lookup_by_extension("m4v").encoding
+  end
+
+  def test_using_custom_content_type_mime_db
+    MiniMime::Configuration.content_type_db_path = CUSTOM_CONTENT_TYPE_MIME_DB_PATH
+
+    assert_equal "liquid", MiniMime.lookup_by_content_type("application/x-liquid").extension
+    assert_equal "quoted-printable", MiniMime.lookup_by_content_type("video/vnd.objectvideo").encoding
+  end
+end


### PR DESCRIPTION
Closes https://github.com/discourse/mini_mime/issues/23.

Adds `MiniMime::Configuration` for changing DB paths. This avoids having to instantiate multiple databases of the same kind and provides a simple API for switching out:

```ruby
MiniMime.configure do |config|
  config.ext_db_path = "some_full_path"
  config.content_type_db_path = "some_other_full_path"
end
```

I'm happy to change/rewrite the implementation if need be.

Benchmark before:
```
Memory stats for requiring mime/types/columnar
Total allocated: 8964072 bytes (106373 objects)
Total retained:  3159081 bytes (33669 objects)

Memory stats for requiring mini_mime
Total allocated: 41136 bytes (362 objects)
Total retained:  7226 bytes (60 objects)
Warming up --------------------------------------
cached content_type lookup MiniMime
                        76.211k i/100ms
content_type lookup MIME::Types
                        14.888k i/100ms
Calculating -------------------------------------
cached content_type lookup MiniMime
                          1.015M (± 1.9%) i/s -      5.106M in   5.032007s
content_type lookup MIME::Types
                        158.069k (± 3.4%) i/s -    803.952k in   5.091533s
Warming up --------------------------------------
uncached content_type lookup MiniMime
                         1.510k i/100ms
content_type lookup MIME::Types
                        14.667k i/100ms
Calculating -------------------------------------
uncached content_type lookup MiniMime
                         15.343k (± 2.1%) i/s -     77.010k in   5.021662s
content_type lookup MIME::Types
                        156.226k (± 4.7%) i/s -    792.018k in   5.079955s
```

Benchmark after:
```
Memory stats for requiring mime/types/columnar
Total allocated: 8964072 bytes (106373 objects)
Total retained:  3159081 bytes (33669 objects)

Memory stats for requiring mini_mime
Total allocated: 44700 bytes (411 objects)
Total retained:  9096 bytes (73 objects)
Warming up --------------------------------------
cached content_type lookup MiniMime
                        74.313k i/100ms
content_type lookup MIME::Types
                        14.482k i/100ms
Calculating -------------------------------------
cached content_type lookup MiniMime
                        981.330k (± 2.3%) i/s -      4.905M in   5.000719s
content_type lookup MIME::Types
                        155.863k (± 3.4%) i/s -    782.028k in   5.022451s
Warming up --------------------------------------
uncached content_type lookup MiniMime
                         1.466k i/100ms
content_type lookup MIME::Types
                        13.281k i/100ms
Calculating -------------------------------------
uncached content_type lookup MiniMime
                         14.546k (± 9.1%) i/s -     73.300k in   5.093917s
content_type lookup MIME::Types
                        150.802k (± 5.2%) i/s -    757.017k in   5.033633s
```