### PR TITLE
List .lookup_by_extension in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ require 'mini_mime'
 MiniMime.lookup_by_filename("a.txt").content_type
 # => "text/plain"
 
+MiniMime.lookup_by_extension("txt").content_type
+# => "text/plain"
+
 MiniMime.lookup_by_content_type("text/plain").extension
 # => "txt"
 


### PR DESCRIPTION
I've found this method by looking at the source code and found it useful
as I had only the extension.