### PR TITLE
Scheduled DB update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,17 +30,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Bundler cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ruby }}-gems-
-      - name: Setup gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4
+          bundler-cache: true
       - name: Rubocop
         run: bundle exec rubocop
         if: "!contains(matrix.ruby, 'jruby')"

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           ruby-version: "2.7"
           bundler-cache: true
+      - name: Update mime-types-data
+        run: bundle update mime-types-data
       - name: Update DB
         run: bundle exec rake rebuild_db
       - name: Create PR

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -1,0 +1,24 @@
+name: Update MIME type DB
+
+on:
+  schedule:
+    # 10am on the 1st every month https://crontab.guru/#0_10_1_*_*
+    - cron: "0 10 1 * *"
+  workflow_dispatch:
+
+jobs:
+  update_db:
+    runs-on: ubuntu-latest
+    name: "Update MIME type DB"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+      - name: Update DB
+        run: bundle exec rake rebuild_db
+      - name: Create PR
+        run: bin/db_pull_request
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/bin/db_pull_request
+++ b/bin/db_pull_request
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "time"
+
+if `git status --porcelain lib/db`.empty?
+  puts "Skipping, no DB changes to commit..."
+  return
+end
+
+moment = Time.now.utc
+branch_name = "db-updates-#{moment.strftime("%Y%m%d%H%M%S")}"
+
+system("git", "checkout", "-b", branch_name)
+system("git", "add", "lib/db")
+system("git", "config", "--local", "user.email", "actions@github.com")
+system("git", "config", "--local", "user.name", "github-actions")
+system("git", "commit", "-m", "DB updates #{moment.iso8601}")
+system("git", "push", "-u", "origin", branch_name)
+system("gh", "pr", "create", "--title", "DB updates #{moment.iso8601}", "--body", "From Github Actions")

--- a/bin/db_pull_request
+++ b/bin/db_pull_request
@@ -11,10 +11,10 @@ end
 moment = Time.now.utc
 branch_name = "db-updates-#{moment.strftime("%Y%m%d%H%M%S")}"
 
-system("git", "checkout", "-b", branch_name)
+system("git", "checkout", "-b", branch_name) || abort("Unable to create branch")
 system("git", "add", "lib/db")
 system("git", "config", "--local", "user.email", "actions@github.com")
 system("git", "config", "--local", "user.name", "github-actions")
-system("git", "commit", "-m", "DB updates #{moment.iso8601}")
-system("git", "push", "-u", "origin", branch_name)
-system("gh", "pr", "create", "--title", "DB updates #{moment.iso8601}", "--body", "From Github Actions")
+system("git", "commit", "-m", "DB updates #{moment.iso8601}") || abort("Unable to commit changes")
+system("git", "push", "-u", "origin", branch_name) || abort("Unable to push branch")
+system("gh", "pr", "create", "--title", "DB updates #{moment.iso8601}", "--body", "From Github Actions") || abort("Unable to create PR")

--- a/lib/db/content_type_mime.db
+++ b/lib/db/content_type_mime.db
@@ -690,6 +690,7 @@ otf         font/otf                                                            
 ttf         font/ttf                                                                  base64          
 woff        font/woff                                                                 base64          
 woff2       font/woff2                                                                base64          
+avif        image/avif                                                                base64          
 cgm         image/cgm                                                                 base64          
 g3          image/g3fax                                                               base64          
 gif         image/gif                                                                 base64          

--- a/lib/db/ext_mime.db
+++ b/lib/db/ext_mime.db
@@ -51,6 +51,7 @@ atomsvc     application/atomsvc+xml                                             
 atx         application/vnd.antix.game-component                                      base64          
 au          audio/basic                                                               base64          
 avi         video/x-msvideo                                                           base64          
+avif        image/avif                                                                base64          
 aw          application/applixware                                                    base64          
 awb         audio/AMR-WB                                                              base64          
 azf         application/vnd.airzip.filesecure.azf                                     base64          
@@ -636,6 +637,7 @@ onetoc2     application/onenote                                                 
 opf         application/oebps-package+xml                                             base64          
 opml        text/x-opml                                                               quoted-printable
 oprc        application/vnd.palm                                                      base64          
+opus        audio/ogg                                                                 base64          
 orf         image/x-olympus-orf                                                       base64          
 org         application/vnd.lotus-organizer                                           base64          
 osf         application/vnd.yamaha.openscoreformat                                    base64          


### PR DESCRIPTION
Hello 👋 ,

I noticed this issue re: 'Automatic updates from mime-types-data' (https://github.com/discourse/mini_mime/issues/30) and thought I'd give it a shot for some Github Actions practice.

Changes:

- Adds a new workflow which rebuilds the DB, and creates a PR if there are changes
  - Scheduled to run once a month
  - Can be triggered manually from the `Actions` tab on Github
- Simplifies the bundler cache for the main `ci.yml` workflow, for parity