### PR TITLE
Make sure the DB file is seekable, use a StringIO wrapper if it's not

### DIFF
--- a/lib/mini_mime.rb
+++ b/lib/mini_mime.rb
@@ -102,6 +102,16 @@ module MiniMime
         @file_length = File.size(@path)
         @rows = @file_length / @row_length
 
+        # Make sure the DB file is seekable, use a StringIO wrapper if it's not
+        is_seekable = (@file.tell == @row_length)
+        begin
+          @file.seek(0)
+        rescue IOError, SystemCallError
+          is_seekable = false
+        end
+        is_seekable = false unless @file.tell == 0
+        @file = StringIO.new(File.read(@path)) unless is_seekable
+
         @hit_cache = Cache.new(MAX_CACHED)
         @miss_cache = Cache.new(MAX_CACHED)
 

--- a/test/mini_mime_test.rb
+++ b/test/mini_mime_test.rb
@@ -12,7 +12,7 @@ class MiniMimeTest < Minitest::Test
   end
 
   def test_extension
-    assert_equal "application/zip", MiniMime.lookup_by_extension("zip").content_type
+    assert_equal "application/zip", MiniMime.lookup_by_extension("zip")&.content_type
   end
 
   def test_mixed_case
@@ -20,17 +20,17 @@ class MiniMimeTest < Minitest::Test
     # irb(main):009:0> MIME::Types.type_for("TxT").first.to_s
     # => "text/plain"
 
-    assert_equal "application/vnd.groove-tool-message", MiniMime.lookup_by_filename("a.GTM").content_type
-    assert_equal "application/zip", MiniMime.lookup_by_extension("ZiP").content_type
+    assert_equal "application/vnd.groove-tool-message", MiniMime.lookup_by_filename("a.GTM")&.content_type
+    assert_equal "application/zip", MiniMime.lookup_by_extension("ZiP")&.content_type
   end
 
   def test_content_type
-    assert_equal "application/vnd.lotus-1-2-3", MiniMime.lookup_by_filename("a.123").content_type
-    assert_equal "application/x-compressed", MiniMime.lookup_by_filename("a.Z").content_type
-    assert_equal "application/vnd.groove-tool-message", MiniMime.lookup_by_filename("a.gtm").content_type
-    assert_equal "application/vnd.HandHeld-Entertainment+xml", MiniMime.lookup_by_filename("a.zmm").content_type
-    assert_equal "text/csv", MiniMime.lookup_by_filename("x.csv").content_type
-    assert_equal "application/x-msaccess", MiniMime.lookup_by_filename("x.mda").content_type
+    assert_equal "application/vnd.lotus-1-2-3", MiniMime.lookup_by_filename("a.123")&.content_type
+    assert_equal "application/x-compressed", MiniMime.lookup_by_filename("a.Z")&.content_type
+    assert_equal "application/vnd.groove-tool-message", MiniMime.lookup_by_filename("a.gtm")&.content_type
+    assert_equal "application/vnd.HandHeld-Entertainment+xml", MiniMime.lookup_by_filename("a.zmm")&.content_type
+    assert_equal "text/csv", MiniMime.lookup_by_filename("x.csv")&.content_type
+    assert_equal "application/x-msaccess", MiniMime.lookup_by_filename("x.mda")&.content_type
 
     assert_nil MiniMime.lookup_by_filename("a.frog")
   end
@@ -69,11 +69,7 @@ class MiniMimeTest < Minitest::Test
         type ||= types.detect(&:registered)
         type ||= types.first
 
-        # if type.content_type != MiniMime.lookup_by_filename("a.#{ext}").content_type
-        #   puts "#{ext} Expected #{type.content_type} Got #{MiniMime.lookup_by_filename("a.#{ext}").content_type}"
-        # end
-
-        assert_equal type.content_type, MiniMime.lookup_by_filename("a.#{ext}").content_type
+        assert_equal type.content_type, MiniMime.lookup_by_filename("a.#{ext}")&.content_type
       end
     end
   end


### PR DESCRIPTION
This (hopefully) fixes https://github.com/discourse/mini_mime/issues/37

What has been tested:

* Still works when not bundled in a .jar, does not use StringIO wrapper.
* Works and uses StringIO wrapper when patched so that the `is_seekable` check always fails.

What has not (yet) been tested:

* Does it actually work with a `uri:classloader` resource in a bundled .jar, with `seek` failing silently?
* Does it work with a non-seekable DB file in other cases, where `seek` might raise an exception?

While I'm 99% confident that the answer to both questions is yes, I'd still like to do a bit more testing. But I wanted to get this PR out for review before the weekend.

(Also, I'm not sure if there are any potential newline and/or UTF-8 conversion issues on some platforms that might require opening the DB files explicitly in binary mode. If there were, I suspect the existing code would already be buggy on such platforms, since it's already seeking around in a file opened in text mode, but I'm still slightly worried and would like to see this tested better.)