### PR TITLE
Add Ruby 3.0 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.4", "2.5", "2.6", "2.7"]
+        ruby: ["2.4", "2.5", "2.6", "2.7", "3.0"]
         experimental: [false]
         include:
           - ruby: "ruby-head"


### PR DESCRIPTION
This change just adds Ruby 3.0 to the CI matrix.