### PR TITLE
Adds Ruby 3.2 to the CI matrix.  Requires Ruby >= 2.6.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
         experimental: [false]
         include:
           - ruby: "ruby-head"
@@ -30,7 +30,7 @@ jobs:
           - ruby: "jruby-9.3.2.0"
             experimental: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
         experimental: [false]
         include:
           - ruby: "ruby-head"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
             experimental: true
           - ruby: "jruby-head"
             experimental: true
-          - ruby: "jruby-9.2.20.1"
+          - ruby: "jruby-9.3.9.0"
             experimental: true
-          - ruby: "jruby-9.3.2.0"
+          - ruby: "jruby-9.4.0.0"
             experimental: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Update MIME type DB"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7"

--- a/mini_mime.gemspec
+++ b/mini_mime.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Added Ruby 3.2 to the CI matrix.  Also upgraded the checkout actions.

Ruby 2.5 no longer passes because it can't get versions of rubocop and rubocop-discourse that allow a clean Rubocop run.  So, given that Ruby 2.5 was removed about a year ago, I chose to resolve this issue by removing Ruby 2.5.

Everything runs green on my fork.