### PR TITLE
Ignore ggs and cjs in the parity test

### DIFF
--- a/test/mini_mime_test.rb
+++ b/test/mini_mime_test.rb
@@ -106,6 +106,15 @@ class MiniMimeTest < Minitest::Test
       "rst" => "text/plain",
     }
 
+    KNOWN_DIFFERENCES = {
+      "ggs" => nil,
+      "cjs" => nil,
+    }
+
+    if RUBY_PLATFORM.match?(/mingw|windows/i)
+      KNOWN_DIFFERENCES.merge!(WINDOWS_TYPES)
+    end
+
     def test_full_parity_with_mime_types
       exts = Set.new
       MIME::Types.each do |type|
@@ -126,10 +135,10 @@ class MiniMimeTest < Minitest::Test
         # end
 
         expected = type.content_type
-        if WINDOWS_TYPES.key?(ext) && RUBY_PLATFORM.match?(/mingw|windows/i)
+        if KNOWN_DIFFERENCES.key?(ext)
           expected = WINDOWS_TYPES[ext]
         end
-        actual = MiniMime.lookup_by_filename("a.#{ext}").content_type
+        actual = MiniMime.lookup_by_filename("a.#{ext}")&.content_type
 
         if expected != actual
           differences << %{Expected ".#{ext}" to return #{expected.inspect}, got: #{actual.inspect}}


### PR DESCRIPTION
cc @SamSaffron 

This is unrelated to recent changes, it's just the latest version of `mime-types-data` added two new types that `mini_mime` doesn't know about.

Ref: https://github.com/mime-types/mime-types-data/commit/02786577194203a143e421354ee74a4a53e568cb